### PR TITLE
background: fix problem with background

### DIFF
--- a/webapp/src/components/Checkout/style.css
+++ b/webapp/src/components/Checkout/style.css
@@ -7,6 +7,7 @@
   left: 0;
   width: 100vw;
   height: 100vh;
+  overflow: auto;
   background-color: var(--color-grey-90);
 }
 


### PR DESCRIPTION
without setting the overflow porperty the background was set to 100% of
the viewport

so if you opened the console for instance, the background wouldn't fill
the entire screen

now it does

closes #65 

thanks to @vitorsilvalima for helping me figure out the problem 
