### PR TITLE
redux: update structure to simplify its use

### DIFF
--- a/webapp/.eslintrc
+++ b/webapp/.eslintrc
@@ -23,6 +23,12 @@
         "ignoreRefs": true,
         "allowBind": true
       }
+    ],
+    "react/prop-types": [
+      2,
+      {
+        "ignore": ["dispatch", "store"]
+      }
     ]
   }
 }

--- a/webapp/src/actions/footerButton.js
+++ b/webapp/src/actions/footerButton.js
@@ -1,7 +1,0 @@
-import { TOOGLE_FOOTER_BUTTON } from '../constants/ActionTypes'
-
-const footerButton = () => ({
-  type: TOOGLE_FOOTER_BUTTON,
-})
-
-export default footerButton

--- a/webapp/src/actions/index.js
+++ b/webapp/src/actions/index.js
@@ -1,6 +1,10 @@
 /* eslint-disable import/prefer-default-export */
-import footerButton from './footerButton'
+import { TOOGLE_FOOTER_BUTTON } from '../constants/ActionTypes'
+
+const toogleFooterButton = () => ({
+  type: TOOGLE_FOOTER_BUTTON,
+})
 
 export {
-  footerButton,
+  toogleFooterButton,
 }

--- a/webapp/src/containers/ShippingPage/index.js
+++ b/webapp/src/containers/ShippingPage/index.js
@@ -9,7 +9,7 @@ import AddressForm from '../../containers/AddressFormContainer'
 import options from '../../helpers/states'
 import { Grid, Row, Col } from '../../components/Grid'
 import Button from '../../components/Button'
-import { footerButton } from '../../actions'
+import { toogleFooterButton } from '../../actions'
 
 const largeColSize = 12
 const mediumColSize = 6
@@ -57,7 +57,7 @@ class Shipping extends Component {
   toggleOpenAddressForm () {
     const openAddressForm = !this.state.openAddressForm
 
-    this.props.footerButton({ visible: !openAddressForm })
+    this.props.dispatch(toogleFooterButton())
     this.setState({ openAddressForm })
   }
 
@@ -244,15 +244,10 @@ Shipping.propTypes = {
     optionBox: PropTypes.string,
   }),
   title: PropTypes.string.isRequired,
-  footerButton: PropTypes.func.isRequired,
 }
 
 Shipping.defaultProps = {
   theme: {},
 }
 
-const mapDispatchToProps = dispatch => ({
-  footerButton: value => dispatch(footerButton(value)),
-})
-
-export default connect(null, mapDispatchToProps)(applyThemr(Shipping))
+export default connect()(applyThemr(Shipping))


### PR DESCRIPTION
for now we can store all actions on the same place and wait for a moment
where we find a pattern to split them

eslint won't yell at us with store and dispatch as props when we use
connect from react-redux