### PR TITLE
button-status: add disabled prop on submit button

### DIFF
--- a/src/pages/Addresses.js
+++ b/src/pages/Addresses.js
@@ -4,7 +4,7 @@ import classNames from 'classnames'
 import { themr } from 'react-css-themr'
 import { connect } from 'react-redux'
 import Form from 'react-vanilla-form'
-import { merge, omit } from 'ramda'
+import { merge, omit, isNil, reject, isEmpty } from 'ramda'
 import { RadioGroup } from 'former-kit'
 
 import {
@@ -105,10 +105,6 @@ class AddressesPage extends Component {
     }
   }
 
-  onChangeAddress = (address) => {
-    this.setState({ selected: address })
-  }
-
   handleZipcodeChange = (e) => {
     const { name, value } = e.target
     const zipcode = removeZipcodeMask(value)
@@ -161,8 +157,11 @@ class AddressesPage extends Component {
     this.shippingNumberInput = input
   }
 
-  handleChangeForm = (values) => {
-    this.setState(values)
+  handleChangeForm = (values, errors) => {
+    this.setState({
+      ...values,
+      formValid: isEmpty(reject(isNil, errors)),
+    })
   }
 
   render () {
@@ -431,6 +430,7 @@ class AddressesPage extends Component {
                 type="submit"
                 className={theme.button}
                 full={!isBigScreen}
+                disabled={!this.state.formValid}
               >
                   Confirmar
               </Button>

--- a/src/pages/Customer.js
+++ b/src/pages/Customer.js
@@ -4,6 +4,7 @@ import classNames from 'classnames'
 import { themr } from 'react-css-themr'
 import { connect } from 'react-redux'
 import Form from 'react-vanilla-form'
+import { isEmpty, reject, isNil } from 'ramda'
 
 import {
   Grid,
@@ -41,8 +42,11 @@ class CustomerPage extends Component {
     })
   }
 
-  handleChangeForm = (values) => {
-    this.setState(values)
+  handleChangeForm = (values, errors) => {
+    this.setState({
+      ...values,
+      formValid: isEmpty(reject(isNil, errors)),
+    })
   }
 
   renderCustomerForm () {
@@ -163,6 +167,7 @@ class CustomerPage extends Component {
               relevance="normal"
               type="submit"
               className={theme.button}
+              disabled={!this.state.formValid}
               full={!isBigScreen}
             >
               Confirmar

--- a/src/pages/Payment.js
+++ b/src/pages/Payment.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import { themr } from 'react-css-themr'
 import classNames from 'classnames'
 import PaymentCard from 'react-payment-card-component'
-import { pick, path, replace } from 'ramda'
+import { pick, path, replace, isNil, reject, isEmpty } from 'ramda'
 import { connect } from 'react-redux'
 import Form from 'react-vanilla-form'
 
@@ -77,8 +77,11 @@ class PaymentPage extends Component {
     this.setState({ selectedPayment: choice })
   }
 
-  handleChangeForm = (values) => {
-    this.setState({ creditcard: values })
+  handleChangeForm = (values, errors) => {
+    this.setState({
+      creditcard: values,
+      formValid: isEmpty(reject(isNil, errors)),
+    })
   }
 
   handleFlipCard = () => {
@@ -259,8 +262,9 @@ class PaymentPage extends Component {
                 type="submit"
                 className={theme.button}
                 full={!isBigScreen}
+                disabled={!this.state.formValid}
               >
-                Confirmar
+                Finalizar compra
               </Button>
             </Col>
           </Row>
@@ -329,7 +333,7 @@ class PaymentPage extends Component {
                 className={theme.button}
                 full={!isBigScreen}
               >
-                Confirmar
+                Finalizar compra
               </Button>
             </Col>
           </Row>

--- a/src/themes/default/button/index.css
+++ b/src/themes/default/button/index.css
@@ -38,17 +38,17 @@
 
 .button:active {
   transform: scale(0.95);
-  background-color: var(--checkout-primary-color);
+  background: var(--checkout-primary-color);
 }
 
 .button:focus {
-  background-color: var(--checkout-primary-color);
+  background: var(--checkout-primary-color);
 }
 
 .button:disabled {
   color: var(--color-grey-39);
   cursor: not-allowed;
-  background-color: var(--color-grey-11);
+  background: var(--color-grey-11);
 }
 
 /*


### PR DESCRIPTION
every submit button should have a disabled prop to mirror the form
status so users cannot even click on them if the form is not valid

this adds a new state key to every page so we can keep track of its form
state

## Description

<!-- Write a brief and explicative description of your pull request. -->

Closes https://github.com/pagarme/mercurio/issues/80
<!--
Things to cite on the PR description:

- Why is the PR needed
- What the PR does
- What are possible side effects
- Additional information (related github issues, links, etc)

  Example: This PR implements feature "x" so we can solve our payments problem. This PR closes #98928312874 (github issue)
-->

## Your checklist for this pull request

:rotating_light: Please review this items for a good pull request. :four_leaf_clover:

1. I've read the project's [Contributing Guidelines](CONTRIBUTING.md)
1. My commits are well written and follow [pagarme/git-style-guide](https://github.com/pagarme/git-style-guide)
1. My changes are well covered by **tests** and **logs**
1. I've updated the project docs (if needed)
1. I fell safe about this implementation

In a good pull request, everything above is true :relaxed:
