### PR TITLE
autocomplete: fix autocomplete address

### DIFF
--- a/src/pages/Addresses.js
+++ b/src/pages/Addresses.js
@@ -124,13 +124,19 @@ class AddressesPage extends Component {
           shippingNeighborhood: address.neighborhood,
           shippingCity: address.city,
           shippingState: address.state,
+          shippingNumber: '',
+          shippingComplement: '',
         })
 
         this.shippingNumberInput.focus()
       } else {
         const newAddress = merge(
           omit(['cep'], address),
-          { zipcode: newZipcode }
+          {
+            zipcode: newZipcode,
+            number: '',
+            complement: '',
+          }
         )
 
         this.setState(newAddress)
@@ -239,6 +245,7 @@ class AddressesPage extends Component {
                     name="number"
                     label="Nº"
                     placeholder="Digite o número"
+                    type="number"
                   />
                 </Col>
                 <Col
@@ -360,6 +367,7 @@ class AddressesPage extends Component {
                       name="shippingNumber"
                       label="Nº"
                       placeholder="Digite o número"
+                      type="number"
                     />
                   </Col>
                   <Col


### PR DESCRIPTION
when you have a previously type address and change it using the cep
autocomplete the number and complement will both change so we should
delete them

Closes https://github.com/pagarme/mercurio/issues/83
<!--
Things to cite on the PR description:

- Why is the PR needed
- What the PR does
- What are possible side effects
- Additional information (related github issues, links, etc)

  Example: This PR implements feature "x" so we can solve our payments problem. This PR closes #98928312874 (github issue)
-->

## Your checklist for this pull request

:rotating_light: Please review this items for a good pull request. :four_leaf_clover:

1. I've read the project's [Contributing Guidelines](CONTRIBUTING.md)
1. My commits are well written and follow [pagarme/git-style-guide](https://github.com/pagarme/git-style-guide)
1. My changes are well covered by **tests** and **logs**
1. I've updated the project docs (if needed)
1. I fell safe about this implementation

In a good pull request, everything above is true :relaxed:
