### PR TITLE
payment-page: fix form validation on switch

### DIFF
--- a/src/pages/Payment/SwitchPayment.js
+++ b/src/pages/Payment/SwitchPayment.js
@@ -13,6 +13,7 @@ import {
   reject,
   isNil,
   pathOr,
+  omit,
 } from 'ramda'
 
 import { Switch, Button } from '../../components'
@@ -146,9 +147,17 @@ class SwitchPayment extends Component {
       { type: paymentType }
     )
 
+    const validatedErrors = omit(paymentType === 'boleto'
+      ? ['cardNumber',
+        'cvv',
+        'expiration',
+        'holderName',
+        'installments']
+      : [], reject(isNil, errors))
+
     const payment = {
       method,
-      formValid: isEmpty(reject(isNil, errors)),
+      formValid: isEmpty(validatedErrors),
       type: paymentType,
     }
 
@@ -175,7 +184,7 @@ class SwitchPayment extends Component {
       pageInfo: payment,
     })
 
-    handleSubmit(data, errors)
+    handleSubmit(data, validatedErrors)
   }
 
   render () {


### PR DESCRIPTION
when using the switch to change between boleto and creditcard, there was
a bug when the creditcard form was invalid and you changed to boleto.

trying to send in this case was validating the errors on the hidden form

## Description

<!-- Write a brief and explicative description of your pull request. -->

Closes https://github.com/pagarme/mercurio/issues/102
<!--
Things to cite on the PR description:

- Why is the PR needed
- What the PR does
- What are possible side effects
- Additional information (related github issues, links, etc)

  Example: This PR implements feature "x" so we can solve our payments problem. This PR closes #98928312874 (github issue)
-->

## Your checklist for this pull request

:rotating_light: Please review this items for a good pull request. :four_leaf_clover:

1. I've read the project's [Contributing Guidelines](CONTRIBUTING.md)
1. My commits are well written and follow [pagarme/git-style-guide](https://github.com/pagarme/git-style-guide)
1. My changes are well covered by **tests** and **logs**
1. I've updated the project docs (if needed)
1. I fell safe about this implementation

In a good pull request, everything above is true :relaxed:
