### PR TITLE
chore: add codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @pagarme/mercurio-devs


### PR DESCRIPTION
this helps us requesting reviews from a specific team without needing to
select each user

I created a team at Pagarme including the mercurio devs, so we can use
it here in this file

see https://blog.github.com/2017-07-06-introducing-code-owners/ for more
info about this feature
