### PR TITLE
page-info: add a method to save in localstorage

### DIFF
--- a/config/jest/browserMocks.js
+++ b/config/jest/browserMocks.js
@@ -1,0 +1,20 @@
+var localStorageMock = (function () {
+  var store = {};
+
+  return {
+    getItem: function (key) {
+      return store[key] || null;
+    },
+    setItem: function (key, value) {
+      store[key] = value.toString();
+    },
+    clear: function () {
+      store = {};
+    }
+  };
+
+})();
+
+Object.defineProperty(window, 'localStorage', {
+  value: localStorageMock
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
   ],
   setupFiles: [
     '<rootDir>/config/jest/setupTests.js',
+    '<rootDir>/config/jest/browserMocks.js',
   ],
   testMatch: [
     '<rootDir>/src/**/__tests__/**/*.js?(x)',

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import ReactGA from 'react-ga'
 import moment from 'moment'
-import { pipe, split, map, of } from 'ramda'
+import { pipe, split, map, merge, of } from 'ramda'
 import 'moment/locale/pt-br'
 
 import App from './App'
@@ -28,6 +28,10 @@ const openCheckout = ({
   apiData,
   acquirer,
 }) => {
+  const storagedPageInfo = JSON.parse(
+    localStorage.getItem('pageInfo')
+  )
+
   const {
     configs = {},
     customer,
@@ -36,7 +40,7 @@ const openCheckout = ({
     cart,
     transaction = {},
     key,
-  } = apiData
+  } = merge(apiData, storagedPageInfo)
 
   const {
     target = 'checkout-wrapper',

--- a/src/reducers/pageInfo.js
+++ b/src/reducers/pageInfo.js
@@ -1,14 +1,34 @@
-const defaultState = { }
+import { merge } from 'ramda'
+
+const defaultState = {}
+
+const formatDataToLocalStorage = (payload, state) => {
+  if (payload.page === 'payment') {
+    return state
+  }
+
+  return JSON.stringify(
+    merge(state, {
+      [payload.page]: payload.pageInfo,
+    })
+  )
+}
 
 const pageInfo = (state = defaultState, action) => {
   const { payload = {} } = action
 
   switch (action.type) {
-    case 'ADD_PAGE_INFO':
+    case 'ADD_PAGE_INFO': {
+      localStorage.setItem('pageInfo', formatDataToLocalStorage(
+        payload,
+        state
+      ))
+
       return {
         ...state,
         [payload.page]: payload.pageInfo,
       }
+    }
 
     default:
       return state


### PR DESCRIPTION
## Description

it saves the form data to localStorage
only the customer, billing and shipping data

once the data is saved, it will be displayed on the form
when the user opens Checkout again. 
**only if the our customer dont pass the parameters (customer, billing and shipping)**

<!-- Write a brief and explicative description of your pull request. -->

Closes https://github.com/pagarme/mercurio/issues/183
<!--
Things to cite on the PR description:

- Why is the PR needed
- What the PR does
- What are possible side effects
- Additional information (related github issues, links, etc)

  Example: This PR implements feature "x" so we can solve our payments problem. This PR closes #98928312874 (github issue)
-->

## Your checklist for this pull request

:rotating_light: Please review this items for a good pull request. :four_leaf_clover:

1. I've read the project's [Contributing Guidelines](CONTRIBUTING.md)
1. My commits are well written and follow [pagarme/git-style-guide](https://github.com/pagarme/git-style-guide)
1. My changes are well covered by **tests** and **logs**
1. I've updated the project docs (if needed)
1. I fell safe about this implementation

In a good pull request, everything above is true :relaxed:
