### PR TITLE
credit-card: fix installments in pagarme simple case

### DIFF
--- a/src/reducers/reducers.test.js
+++ b/src/reducers/reducers.test.js
@@ -17,7 +17,11 @@ describe('checkout reduceres', () => {
         paymentConfig: {
           boleto: {},
           creditcard: {
-            installments: [],
+            installments: [{
+              free: 10,
+              initial: 2,
+              max: 10,
+            }],
           },
         },
       },
@@ -132,7 +136,11 @@ describe('checkout reduceres', () => {
         paymentConfig: {
           boleto: {},
           creditcard: {
-            installments: [],
+            installments: [{
+              free: 10,
+              initial: 2,
+              max: 10,
+            }],
           },
         },
         paymentMethods: [],
@@ -161,7 +169,11 @@ describe('checkout reduceres', () => {
         paymentConfig: {
           boleto: {},
           creditcard: {
-            installments: [],
+            installments: [{
+              free: 10,
+              initial: 2,
+              max: 10,
+            }],
           },
         },
         paymentMethods: [],
@@ -188,7 +200,11 @@ describe('checkout reduceres', () => {
         paymentConfig: {
           boleto: {},
           creditcard: {
-            installments: [],
+            installments: [{
+              free: 10,
+              initial: 2,
+              max: 10,
+            }],
           },
         },
         paymentMethods: [],

--- a/src/reducers/transactionValues.js
+++ b/src/reducers/transactionValues.js
@@ -7,7 +7,11 @@ const defaultState = {
   paymentConfig: {
     boleto: {},
     creditcard: {
-      installments: [],
+      installments: [{
+        free: 10,
+        initial: 2,
+        max: 10,
+      }],
     },
   },
 }


### PR DESCRIPTION
## Description

### Problem
I'm not finishing credit card transaction done, because the field "installments" is rendering empty.

### Cause
The `installments` array from reducer is empty

### Solution
Fill the array with basic information

<!-- Write a brief and explicative description of your pull request. -->

Closes https://github.com/pagarme/mercurio/issues/210
<!--
Things to cite on the PR description:

- Why is the PR needed
- What the PR does
- What are possible side effects
- Additional information (related github issues, links, etc)

  Example: This PR implements feature "x" so we can solve our payments problem. This PR closes #98928312874 (github issue)
-->

## Your checklist for this pull request

:rotating_light: Please review this items for a good pull request. :four_leaf_clover:

1. I've read the project's [Contributing Guidelines](CONTRIBUTING.md)
1. My commits are well written and follow [pagarme/git-style-guide](https://github.com/pagarme/git-style-guide)
1. My changes are well covered by **tests** and **logs**
1. I've updated the project docs (if needed)
1. I fell safe about this implementation

In a good pull request, everything above is true :relaxed:
