### PR TITLE
checkout: add css to body when open/close

### DIFF
--- a/src/containers/Checkout/index.js
+++ b/src/containers/Checkout/index.js
@@ -48,6 +48,7 @@ import {
   isFormValid,
 } from '../../utils/validations'
 import calcAmount from '../../utils/calculations/calcAmount'
+import { insertStaticPosition } from '../../utils/helpers/bodyCss'
 
 import {
   AnalysisInfo,
@@ -492,6 +493,7 @@ class Checkout extends React.Component {
         targetElement
       )
       if (onClose) {
+        insertStaticPosition()
         onClose()
       }
     }, 500)

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,7 @@ import getColors from './utils/helpers/getColors'
 import setTheme from './utils/helpers/setTheme'
 import setColors from './utils/helpers/setColors'
 import getParentElement from './utils/helpers/getParentElement'
+import { insertRelativePosition } from './utils/helpers/bodyCss'
 
 moment.locale('pt-br')
 
@@ -73,6 +74,8 @@ const openCheckout = (apiData, clientThemeBase, form, colors) => {
   )(acquirerName)
 
   const store = createStore(apiData)
+
+  insertRelativePosition()
 
   ReactDOM.render(
     <App

--- a/src/utils/helpers/bodyCss.js
+++ b/src/utils/helpers/bodyCss.js
@@ -1,0 +1,11 @@
+const changePosition = (position) => {
+  document.body.style.position = position
+}
+
+const insertRelativePosition = () => changePosition('relative')
+const insertStaticPosition = () => changePosition('static')
+
+export {
+  insertRelativePosition,
+  insertStaticPosition,
+}


### PR DESCRIPTION
## Description
Em dispositivos mobile o checkout não ocupava a tela inteira. Foi inserido o `position: relative` no `body` ao abri-lo, e ao fechá-lo ele é retirado do `body`.

<!-- Write a brief and explicative description of your pull request. -->

Closes https://github.com/pagarme/mercurio/issues/320 
<!--
Things to cite on the PR description:

- Why is the PR needed
- What the PR does
- What are possible side effects
- Additional information (related github issues, links, etc)

  Example: This PR implements feature "x" so we can solve our payments problem. This PR closes #98928312874 (github issue)
-->

## Your checklist for this pull request

:rotating_light: Please review this items for a good pull request. :four_leaf_clover:

1. I've read the project's [Contributing Guidelines](CONTRIBUTING.md)
1. My commits are well written and follow [pagarme/git-style-guide](https://github.com/pagarme/git-style-guide)
1. My changes are well covered by **tests** and **logs**
1. I've updated the project docs (if needed)
1. I fell safe about this implementation

In a good pull request, everything above is true :relaxed:
