### PR TITLE
shipping: fix showing page and switch

### DIFF
--- a/cypress/helpers/custom.js
+++ b/cypress/helpers/custom.js
@@ -20,8 +20,18 @@ function fillAddressPage (zipcode = '03675030', number = '123') {
   cy.get('input[name="number"]').type(number)
 }
 
+function cyGet (query, options) {
+  const newOptions = {
+    timeout: 950,
+    ...options,
+  }
+
+  return cy.get(query, newOptions)
+}
+
 export {
   fillAddressPage,
   fillCustomerPage,
   openCustomWithParams,
+  cyGet,
 }

--- a/cypress/integration/custom/api/shipping.spec.js
+++ b/cypress/integration/custom/api/shipping.spec.js
@@ -1,3 +1,5 @@
+import { cyGet } from '../../../helpers/custom'
+
 describe('Custom', () => {
   describe('API', () => {
     describe('Shipping', () => {
@@ -53,244 +55,284 @@ describe('Custom', () => {
 
           cy.visit('/')
 
-          cy.get('#btn-open-textarea').click()
-          cy.get('#textarea-code').type(api)
-          cy.get('#btn-open-checkout').click()
-          cy.wait(300)
+          cyGet('#btn-open-textarea').click()
+          cyGet('#textarea-code').type(api)
+          cyGet('#btn-open-checkout').click()
 
-          cy.get('.customerPage__title').should('not.exist')
-          cy.get('.addressesPage__title').should('not.exist')
-          cy.get('.paymentoptionsPage__title').then((elem) => {
-            expect(elem[0].innerHTML).to.eq('Como quer pagar?')
-          })
+          cyGet('.customerPage__title').should('not.exist')
+          cyGet('.addressesPage__title').should('not.exist')
+          cyGet('.paymentoptionsPage__title').should('have.html', 'Como quer pagar?')
 
-          cy.get('.actionButton__wrapper > button').should('exist')
-          cy.get('.actionButton__wrapper > button').then((elem) => {
+          cyGet('.actionButton__wrapper > button').should('exist')
+          cyGet('.actionButton__wrapper > button').then((elem) => {
             expect(elem.length).to.eq(2)
             expect(elem[0].innerText).contains('CARTÃO DE CRÉDITO')
             expect(elem[1].innerText).contains('BOLETO')
           })
         })
-        describe('with antifraude enable', () => {
-          it('and tangible itens and billing on payload', () => {
-            const api = `
-            const key = 'ek_test_sjQXl3mVUFu1QQYpiSvUBaybtXtXjz';
+      })
+      it('should show page without shipping data', () => {
+        const api = `
+          const key = 'ek_test_sjQXl3mVUFu1QQYpiSvUBaybtXtXjz';
 
-            const customer = {
-              name: 'Dan Abramov',
-              documentNumber: '19981596639',
-              email: 'mercurio@pagar.me',
-              phoneNumber: '1130442277',
-              allowedDocuments: ['CPF', 'CNPJ'],
-            }
+          const customer = {
+            name: 'Dan Abramov',
+            documentNumber: '19981596639',
+            email: 'mercurio@pagar.me',
+            phoneNumber: '1130442277',
+            allowedDocuments: ['CPF', 'CNPJ'],
+          }
 
-            const billing = {
-              street: 'Rua Fidêncio Ramos',
-              number: '308',
-              additionalInfo: 'Pagar.me',
-              neighborhood: 'Vila Olimpia',
-              city: 'São Paulo',
-              state: 'SP',
-              zipcode: '04551010',
-            }
+          const billing = {
+            street: 'Rua Fidêncio Ramos',
+            number: '308',
+            additionalInfo: 'Pagar.me',
+            neighborhood: 'Vila Olimpia',
+            city: 'São Paulo',
+            state: 'SP',
+            zipcode: '04551010',
+          }
 
-            const cart = {
-              items: [
-                {
-                  id: 1,
-                  title: 'Red pill',
-                  unitPrice: 5000,
-                  quantity: 1,
-                  tangible: true,
-                },
-                {
-                  id: 2,
-                  title: 'Blue pill',
-                  unitPrice: 5000,
-                  quantity: 1,
-                  tangible: true,
-                },
-              ],
-            }
+          const transaction = {
+            amount: 10000,
+          }
 
-            const transaction = {
-              amount: 10000,
-            }
-
-            const checkout = createCheckout({
-              customer,
-              billing,
-              key,
-              transaction,
-              cart,
-            })
-
-            checkout
-              .open()
-            `
-
-            cy.visit('/')
-
-            cy.get('#btn-open-textarea').click()
-            cy.get('#textarea-code').type(api)
-            cy.get('#btn-open-checkout').click()
-            cy.wait(300)
-
-            cy.get('.addressesPage__switchLabel').should('exist')
-            cy.get('.addressesPage__switchLabel').then((elem) => {
-              expect(elem[0].innerHTML).to.eq('Entregar no mesmo endereço?')
-            })
+          const checkout = createCheckout({
+            customer,
+            billing,
+            key,
+            transaction,
           })
 
-          it('and without tangible itens and billing on payload', () => {
+          checkout
+            .open()
+        `
+
+        cy.visit('/')
+
+        cyGet('#btn-open-textarea').click()
+        cyGet('#textarea-code').type(api)
+        cyGet('#btn-open-checkout').click()
+
+        cyGet('.switch__switch').click()
+
+        cyGet('[type="submit"]:last').click()
+
+        cyGet('.addressesPage__title').should('have.html', 'Onde devemos fazer a entrega?')
+      })
+      describe('With antifraud enabled', () => {
+        describe('and tangible itens and billing on payload', () => {
+          it('should go to shipping page', () => {
             const api = `
-            const key = 'ek_test_sjQXl3mVUFu1QQYpiSvUBaybtXtXjz';
+              const key = 'ek_test_sjQXl3mVUFu1QQYpiSvUBaybtXtXjz';
 
-            const customer = {
-              name: 'Dan Abramov',
-              documentNumber: '19981596639',
-              email: 'mercurio@pagar.me',
-              phoneNumber: '1130442277',
-              allowedDocuments: ['CPF', 'CNPJ'],
-            }
+              const configs = {
+                antifraud: true,
+              }
 
-            const billing = {
-              street: 'Rua Fidêncio Ramos',
-              number: '308',
-              additionalInfo: 'Pagar.me',
-              neighborhood: 'Vila Olimpia',
-              city: 'São Paulo',
-              state: 'SP',
-              zipcode: '04551010',
-            }
+              const customer = {
+                name: 'Dan Abramov',
+                documentNumber: '19981596639',
+                email: 'mercurio@pagar.me',
+                phoneNumber: '1130442277',
+                allowedDocuments: ['CPF', 'CNPJ'],
+              }
 
-            const cart = {
-              items: [
-                {
-                  id: 1,
-                  title: 'Red pill',
-                  unitPrice: 5000,
-                  quantity: 1,
-                  tangible: false,
-                },
-                {
-                  id: 2,
-                  title: 'Blue pill',
-                  unitPrice: 5000,
-                  quantity: 1,
-                  tangible: false,
-                },
-              ],
-            }
+              const billing = {
+                street: 'Rua Fidêncio Ramos',
+                number: '308',
+                additionalInfo: 'Pagar.me',
+                neighborhood: 'Vila Olimpia',
+                city: 'São Paulo',
+                state: 'SP',
+                zipcode: '04551010',
+              }
 
-            const transaction = {
-              amount: 10000,
-            }
+              const cart = {
+                items: [
+                  {
+                    id: 1,
+                    title: 'Red pill',
+                    unitPrice: 5000,
+                    quantity: 1,
+                    tangible: true,
+                  },
+                  {
+                    id: 2,
+                    title: 'Blue pill',
+                    unitPrice: 5000,
+                    quantity: 1,
+                    tangible: true,
+                  },
+                ],
+              }
 
-            const checkout = createCheckout({
-              customer,
-              billing,
-              key,
-              transaction,
-              cart,
-            })
+              const transaction = {
+                amount: 10000,
+              }
 
-            checkout
-              .open()
+              const checkout = createCheckout({
+                configs,
+                customer,
+                billing,
+                key,
+                transaction,
+                cart,
+              })
+
+              checkout
+                .open()
             `
 
             cy.visit('/')
 
-            cy.get('#btn-open-textarea').click()
-            cy.get('#textarea-code').type(api)
-            cy.get('#btn-open-checkout').click()
-            cy.wait(300)
+            cyGet('#btn-open-textarea').click()
+            cyGet('#textarea-code').type(api)
+            cyGet('#btn-open-checkout').click()
 
-            cy.get('.addressesPage__switchLabel').should('not.exist')
+            cyGet('.addressesPage__switchLabel').should('exist')
+            cyGet('.addressesPage__switchLabel').should('have.html', 'Entregar no mesmo endereço?')
           })
         })
-        describe('with antifraude disabled', () => {
-          it('and without tangible itens and billing on payload', () => {
+
+        describe('and without tangible itens and billing on payload', () => {
+          it('should go to shipping page', () => {
             const api = `
-            const key = 'ek_test_sjQXl3mVUFu1QQYpiSvUBaybtXtXjz';
+              const key = 'ek_test_sjQXl3mVUFu1QQYpiSvUBaybtXtXjz';
 
-            const configs = {
-              antifraude: false,
-            }
+              const configs = {
+                antifraud: true,
+              }
 
-            const customer = {
-              name: 'Dan Abramov',
-              documentNumber: '19981596639',
-              email: 'mercurio@pagar.me',
-              phoneNumber: '1130442277',
-              allowedDocuments: ['CPF', 'CNPJ'],
-            }
+              const customer = {
+                name: 'Dan Abramov',
+                documentNumber: '19981596639',
+                email: 'mercurio@pagar.me',
+                phoneNumber: '1130442277',
+                allowedDocuments: ['CPF', 'CNPJ'],
+              }
 
-            const billing = {
-              street: 'Rua Fidêncio Ramos',
-              number: '308',
-              additionalInfo: 'Pagar.me',
-              neighborhood: 'Vila Olimpia',
-              city: 'São Paulo',
-              state: 'SP',
-              zipcode: '04551010',
-            }
+              const billing = {
+                street: 'Rua Fidêncio Ramos',
+                number: '308',
+                additionalInfo: 'Pagar.me',
+                neighborhood: 'Vila Olimpia',
+                city: 'São Paulo',
+                state: 'SP',
+                zipcode: '04551010',
+              }
 
-            const cart = {
-              items: [
-                {
-                  id: 1,
-                  title: 'Red pill',
-                  unitPrice: 5000,
-                  quantity: 1,
-                  tangible: false,
-                },
-                {
-                  id: 2,
-                  title: 'Blue pill',
-                  unitPrice: 5000,
-                  quantity: 1,
-                  tangible: false,
-                },
-              ],
-            }
+              const cart = {
+                items: [
+                  {
+                    id: 1,
+                    title: 'Red pill',
+                    unitPrice: 5000,
+                    quantity: 1,
+                    tangible: false,
+                  },
+                ],
+              }
 
-            const transaction = {
-              amount: 10000,
-            }
+              const transaction = {
+                amount: 10000,
+              }
 
-            const checkout = createCheckout({
-              customer,
-              configs,
-              billing,
-              key,
-              transaction,
-              cart,
-            })
+              const checkout = createCheckout({
+                configs,
+                customer,
+                billing,
+                key,
+                transaction,
+                cart,
+              })
 
-            checkout
-              .open()
+              checkout
+                .open()
             `
 
             cy.visit('/')
 
-            cy.get('#btn-open-textarea').click()
-            cy.get('#textarea-code').type(api)
-            cy.get('#btn-open-checkout').click()
-            cy.wait(300)
+            cyGet('#btn-open-textarea').click()
+            cyGet('#textarea-code').type(api)
+            cyGet('#btn-open-checkout').click()
 
-            cy.get('.paymentoptionsPage__title').should('exist')
-            cy.get('.paymentoptionsPage__title').then((elem) => {
-              expect(elem[0].innerHTML).to.eq('Como quer pagar?')
-            })
+            cyGet('.addressesPage__switchLabel').should('have.html', 'Entregar no mesmo endereço?')
           })
-
-          it('and with tangible itens and billing on payload', () => {
-            const api = `
+        })
+      })
+      describe('With antifraud disabled', () => {
+        it('and without tangible itens and billing on payload', () => {
+          const api = `
             const key = 'ek_test_sjQXl3mVUFu1QQYpiSvUBaybtXtXjz';
 
             const configs = {
-              antifraude: false,
+              antifraud: false,
+            }
+
+            const customer = {
+              name: 'Dan Abramov',
+              documentNumber: '19981596639',
+              email: 'mercurio@pagar.me',
+              phoneNumber: '1130442277',
+              allowedDocuments: ['CPF', 'CNPJ'],
+            }
+
+            const billing = {
+              street: 'Rua Fidêncio Ramos',
+              number: '308',
+              additionalInfo: 'Pagar.me',
+              neighborhood: 'Vila Olimpia',
+              city: 'São Paulo',
+              state: 'SP',
+              zipcode: '04551010',
+            }
+
+            const cart = {
+              items: [
+                {
+                  id: 1,
+                  title: 'Red pill',
+                  unitPrice: 5000,
+                  quantity: 1,
+                  tangible: false,
+                },
+              ],
+            }
+
+            const transaction = {
+              amount: 10000,
+            }
+
+            const checkout = createCheckout({
+              customer,
+              configs,
+              billing,
+              key,
+              transaction,
+              cart,
+            })
+
+            checkout
+              .open()
+          `
+
+          cy.visit('/')
+
+          cyGet('#btn-open-textarea').click()
+          cyGet('#textarea-code').type(api)
+          cyGet('#btn-open-checkout').click()
+
+          cyGet('.paymentoptionsPage__title').should('exist')
+          cyGet('.paymentoptionsPage__title').should('have.html', 'Como quer pagar?')
+        })
+
+        it('and with tangible itens and billing on payload', () => {
+          const api = `
+            const key = 'ek_test_sjQXl3mVUFu1QQYpiSvUBaybtXtXjz';
+
+            const configs = {
+              antifraud: false,
             }
 
             const customer = {
@@ -345,16 +387,283 @@ describe('Custom', () => {
 
             checkout
               .open()
+          `
+
+          cy.visit('/')
+
+          cyGet('#btn-open-textarea').click()
+          cyGet('#textarea-code').type(api)
+          cyGet('#btn-open-checkout').click()
+
+          cyGet('.addressesPage__switchLabel').should('exist')
+        })
+      })
+      describe('Shipping switch button', () => {
+        describe('with antifraud', () => {
+          it('should be visible with tangible itens', () => {
+            const api = `
+              const key = 'ek_test_sjQXl3mVUFu1QQYpiSvUBaybtXtXjz';
+
+              const configs = {
+                antifraud: true
+              }
+
+              const cart = {
+                items: [
+                  {
+                    id: 1,
+                    title: 'Red pill',
+                    unitPrice: 5000,
+                    quantity: 1,
+                    tangible: true,
+                  },
+                ]
+              }
+
+              const customer = {
+                name: 'Dan Abramov',
+                documentNumber: '19981596639',
+                email: 'mercurio@pagar.me',
+                phoneNumber: '1130442277',
+                allowedDocuments: ['CPF', 'CNPJ'],
+              }
+
+              const billing = {
+                street: 'Rua Fidêncio Ramos',
+                number: '308',
+                additionalInfo: 'Pagar.me',
+                neighborhood: 'Vila Olimpia',
+                city: 'São Paulo',
+                state: 'SP',
+                zipcode: '04551010',
+              }
+
+              const transaction = {
+                amount: 10000,
+              }
+
+              const checkout = createCheckout({
+                configs,
+                customer,
+                billing,
+                key,
+                transaction,
+              })
+
+              checkout
+                .open()
             `
 
             cy.visit('/')
 
-            cy.get('#btn-open-textarea').click()
-            cy.get('#textarea-code').type(api)
-            cy.get('#btn-open-checkout').click()
-            cy.wait(300)
+            cyGet('#btn-open-textarea').click()
+            cyGet('#textarea-code').type(api)
+            cyGet('#btn-open-checkout').click()
 
-            cy.get('.addressesPage__switchLabel').should('not.exist')
+            cyGet('.switch__switch').click()
+
+            cyGet('[type="submit"]:last').click()
+
+            cyGet('.addressesPage__title').should('have.html', 'Onde devemos fazer a entrega?')
+          })
+          it('should be visible with intangible itens', () => {
+            const api = `
+              const key = 'ek_test_sjQXl3mVUFu1QQYpiSvUBaybtXtXjz';
+
+              const configs = {
+                antifraud: true
+              }
+
+              const cart = {
+                items: [
+                  {
+                    id: 1,
+                    title: 'Red pill',
+                    unitPrice: 5000,
+                    quantity: 1,
+                    tangible: false,
+                  },
+                ]
+              }
+
+              const customer = {
+                name: 'Dan Abramov',
+                documentNumber: '19981596639',
+                email: 'mercurio@pagar.me',
+                phoneNumber: '1130442277',
+                allowedDocuments: ['CPF', 'CNPJ'],
+              }
+
+              const billing = {
+                street: 'Rua Fidêncio Ramos',
+                number: '308',
+                additionalInfo: 'Pagar.me',
+                neighborhood: 'Vila Olimpia',
+                city: 'São Paulo',
+                state: 'SP',
+                zipcode: '04551010',
+              }
+
+              const transaction = {
+                amount: 10000,
+              }
+
+              const checkout = createCheckout({
+                configs,
+                customer,
+                billing,
+                key,
+                transaction,
+              })
+
+              checkout
+                .open()
+            `
+
+            cy.visit('/')
+
+            cyGet('#btn-open-textarea').click()
+            cyGet('#textarea-code').type(api)
+            cyGet('#btn-open-checkout').click()
+
+            cyGet('.switch__switch').click()
+
+            cyGet('[type="submit"]:last').click()
+
+            cyGet('.addressesPage__title').should('have.html', 'Onde devemos fazer a entrega?')
+          })
+        })
+        describe('without antifraud', () => {
+          it('should be visible with tangible itens', () => {
+            const api = `
+              const key = 'ek_test_sjQXl3mVUFu1QQYpiSvUBaybtXtXjz';
+
+              const configs = {
+                antifraud: false
+              }
+
+              const cart = {
+                items: [
+                  {
+                    id: 1,
+                    title: 'Red pill',
+                    unitPrice: 5000,
+                    quantity: 1,
+                    tangible: true,
+                  },
+                ]
+              }
+
+              const customer = {
+                name: 'Dan Abramov',
+                documentNumber: '19981596639',
+                email: 'mercurio@pagar.me',
+                phoneNumber: '1130442277',
+                allowedDocuments: ['CPF', 'CNPJ'],
+              }
+
+              const billing = {
+                street: 'Rua Fidêncio Ramos',
+                number: '308',
+                additionalInfo: 'Pagar.me',
+                neighborhood: 'Vila Olimpia',
+                city: 'São Paulo',
+                state: 'SP',
+                zipcode: '04551010',
+              }
+
+              const transaction = {
+                amount: 10000,
+              }
+
+              const checkout = createCheckout({
+                configs,
+                customer,
+                billing,
+                cart,
+                key,
+                transaction,
+              })
+
+              checkout
+                .open()
+            `
+
+            cy.visit('/')
+
+            cyGet('#btn-open-textarea').click()
+            cyGet('#textarea-code').type(api)
+            cyGet('#btn-open-checkout').click()
+
+            cyGet('.switch__switch').should('exist')
+
+            cyGet('[type="submit"]:last').click()
+
+            cyGet('.paymentoptionsPage__title').should('have.html', 'Como quer pagar?')
+          })
+          it('should be invisible with intangible itens', () => {
+            const api = `
+              const key = 'ek_test_sjQXl3mVUFu1QQYpiSvUBaybtXtXjz';
+
+              const configs = {
+                antifraud: false,
+              }
+
+              const cart = {
+                items: [
+                  {
+                    id: 1,
+                    title: 'Red pill',
+                    unitPrice: 5000,
+                    quantity: 1,
+                    tangible: false,
+                  },
+                ]
+              }
+
+              const customer = {
+                name: 'Dan Abramov',
+                documentNumber: '19981596639',
+                email: 'mercurio@pagar.me',
+                phoneNumber: '1130442277',
+                allowedDocuments: ['CPF', 'CNPJ'],
+              }
+
+              const billing = {
+                street: 'Rua Fidêncio Ramos',
+                number: '308',
+                additionalInfo: 'Pagar.me',
+                neighborhood: 'Vila Olimpia',
+                city: 'São Paulo',
+                state: 'SP',
+                zipcode: '04551010',
+              }
+
+              const transaction = {
+                amount: 10000,
+              }
+
+              const checkout = createCheckout({
+                configs,
+                customer,
+                cart,
+                billing,
+                key,
+                transaction,
+              })
+
+              checkout
+                .open()
+            `
+
+            cy.visit('/')
+
+            cyGet('#btn-open-textarea').click()
+            cyGet('#textarea-code').type(api)
+            cyGet('#btn-open-checkout').click()
+
+            cyGet('.switch__switch').should('not.exist')
+            cyGet('.paymentoptionsPage__title').should('have.html', 'Como quer pagar?')
           })
         })
       })

--- a/public/assets/js/customParameters.js
+++ b/public/assets/js/customParameters.js
@@ -19,7 +19,7 @@ const configs = {
   enableCart: true,
   createTransaction: true,
   allowSaveCreditCard: true,
-  antifraude: false,
+  antifraud: false,
   postback: 'http://pagar.me',
 }
 

--- a/src/containers/Checkout/index.js
+++ b/src/containers/Checkout/index.js
@@ -341,6 +341,11 @@ class Checkout extends React.Component {
 
   navigateToPage () {
     const value = pathOr('', ['machineState', 'value'], this.props)
+    const antifraud = pathOr(
+      true,
+      ['apiData', 'configs', 'antifraud'],
+      this.props
+    )
     const page = getActiveStep(value)
     const tangible = prop('tangible')
     const cartItems = pathOr([], ['apiData', 'cart', 'items'], this.props)
@@ -350,8 +355,7 @@ class Checkout extends React.Component {
     if (
       page === 'addresses' &&
       hasRequiredPageData(page, this.props, 'billing') &&
-      !isAllItemsTangible &&
-      cartItems.length > 0
+      (!isAllItemsTangible && !antifraud)
     ) {
       const haveAddresses = propEq('page', 'addresses')
       this.setState({
@@ -599,7 +603,7 @@ class Checkout extends React.Component {
       'allowSaveCreditCard',
     ], apiData)
 
-    const antifraude = pathOr(true, ['configs', 'antifraude'], apiData)
+    const antifraud = pathOr(true, ['configs', 'antifraud'], apiData)
     const cartItems = pathOr([], ['cart', 'items'], apiData)
     const pagesCallbacks = path(['callbacks', 'pages'], apiData)
     const customerCallbacks = prop('customer')(pagesCallbacks)
@@ -639,7 +643,7 @@ class Checkout extends React.Component {
             handlePreviousButton={this.navigatePreviousPage}
             enableCart={enableCart}
             handleSubmit={this.handleBillingFormSubmit}
-            antifraude={antifraude}
+            antifraud={antifraud}
             cartItems={cartItems}
           />
         </State>

--- a/src/pages/Billing.js
+++ b/src/pages/Billing.js
@@ -171,7 +171,7 @@ class BillingPage extends Component {
     } = this.state
 
     const {
-      antifraude,
+      antifraud,
       cartItems,
       theme,
       enableCart,
@@ -179,7 +179,7 @@ class BillingPage extends Component {
       sameAddressForShipping,
     } = this.props
 
-    const showSwitch = antifraude && (isAllItemsTangible(cartItems) || cartItems.length === 0) //eslint-disable-line
+    const showSwitch = antifraud || isAllItemsTangible(cartItems)
 
     return (
       <Form
@@ -297,7 +297,7 @@ class BillingPage extends Component {
 }
 
 BillingPage.propTypes = {
-  antifraude: PropTypes.bool.isRequired,
+  antifraud: PropTypes.bool.isRequired,
   cartItems: PropTypes.arrayOf(PropTypes.object).isRequired,
   theme: PropTypes.shape({
     addressForm: PropTypes.string,


### PR DESCRIPTION
## Description
### Problem
A página de endereço de entrega, e o botão "mandar para o mesmo endereço", presente na tela de cobrança, sempre é mostrado, mesmo se o antifraude estiver como false e/ou os itens do carrinho estiverem intangíveis.

### Solução
O condicional estava errado. Ele deve mostrar esse botão se uma das condições forem verdadeiras.

<!-- Write a brief and explicative description of your pull request. -->

References https://github.com/pagarme/tecnologia-vendas/issues/63
<!--
Things to cite on the PR description:

- Why is the PR needed
- What the PR does
- What are possible side effects
- Additional information (related github issues, links, etc)

  Example: This PR implements feature "x" so we can solve our payments problem. This PR closes #98928312874 (github issue)
-->

## Your checklist for this pull request

:rotating_light: Please review this items for a good pull request. :four_leaf_clover:

1. I've read the project's [Contributing Guidelines](CONTRIBUTING.md)
1. My commits are well written and follow [pagarme/git-style-guide](https://github.com/pagarme/git-style-guide)
1. My changes are well covered by **tests** and **logs**
1. I've updated the project docs (if needed)
1. I fell safe about this implementation

In a good pull request, everything above is true :relaxed:
